### PR TITLE
Added contact info for BMZ

### DIFF
--- a/collection.yaml
+++ b/collection.yaml
@@ -41,6 +41,14 @@ config:
     - model
   default_type: model
   url_root: https://github.com/qupath/qupath-bioimage-io
+  docs: https://qupath.readthedocs.io/en/stable/
+  contact:
+    - name: Pete Bankhead 
+      email: p.bankhead@ed.ac.uk
+      github: petebankhead
+      affiliation:
+        - name: UoE
+          url: https://www.ed.ac.uk
 
 collection:
   - id: QuPath


### PR DESCRIPTION
Due to changes in the available documentation for the BioImage Model Zoo (bioimage.io) regarding the Community Partners, new contact info for QuPath needed to be added to the manifest.

Please, make any changes if needed.